### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ You can use `log-analysis.turnOnFocusMode` command to activate focus mode for th
 ### Import and Export
 
 The filters can be imported and exported as json files. Related commands are `log-analysis.exportFilters` and `log-analysis.importFilters` and the ... icon on the top of the tab can achieve the same goal.
+
+## Handling Huge Files
+
+In VS Code, when opening files larger than 50MB, the use of extensions is restricted to ensure performance and memory efficiency. This limitation helps maintain a responsive and stable environment when handling large files. More details on this can be found in [#31078](https://github.com/microsoft/vscode/issues/31078). By using the extension below, you can enable extension functionality when opening large files, allowing for log analysis.
+
+It works well with [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/mbehr1.vsc-lfs?color=green&label=vsc-lfs&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=mbehr1.vsc-lfs) to handle large log files.


### PR DESCRIPTION
support for analysis of huge files

In VS Code, when opening files larger than 50MB, the use of extensions is restricted to ensure performance and memory efficiency. This limitation helps maintain a responsive and stable environment when handling large files. You can bypass this limitation and use log-analysis on large files by the vsc-lfs extension. This tool enables the handling of large files in VS Code, allowing you to apply log-analysis capabilities.