### PR TITLE
add feature: support for managing groups by project

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,12 +77,38 @@
         "icon": "$(plus)"
       },
       {
-        "command": "log-analysis.exportFilters",
-        "title": "Export Filters"
+        "command": "log-analysis.deleteProject",
+        "title": "Delete This Project",
+        "icon": "$(dialog-close)"
       },
       {
-        "command": "log-analysis.importFilters",
-        "title": "Import Filters"
+        "command": "log-analysis.editProject",
+        "title": "Edit a new name for This Project",
+        "icon": "$(edit)"
+      },
+      {
+        "command": "log-analysis.addProject",
+        "title": "Add Project",
+        "icon": "$(repo-create)"
+      },
+      {
+        "command": "log-analysis.openSettings",
+        "title": "Open Settings",
+        "icon": "$(gear)"
+      },
+      {
+        "command": "log-analysis.refreshSettings",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "log-analysis.saveProject",
+        "title": "Save groups to project",
+        "icon": "$(save-as)"
+      },
+      {
+        "command": "log-analysis.selectProject",
+        "title": "Select project"
       }
     ],
     "menus": {
@@ -100,6 +126,11 @@
         {
           "command": "log-analysis.editFilter",
           "when": "view == filters && viewItem =~ /^f-/",
+          "group": "inline@2"
+        },
+        {
+          "command": "log-analysis.editProject",
+          "when": "view == filters.settings",
           "group": "inline@2"
         },
         {
@@ -131,6 +162,11 @@
           "command": "log-analysis.deleteFilter",
           "when": "view == filters && viewItem =~ /^f-/",
           "group": "inline@5"
+        },
+        {
+          "command": "log-analysis.deleteProject",
+          "when": "view == filters.settings",
+          "group": "inline@5"
         }
       ],
       "view/title": [
@@ -145,12 +181,24 @@
           "group": "navigation@2"
         },
         {
-          "command": "log-analysis.importFilters",
-          "when": "view == filters"
+          "command": "log-analysis.saveProject",
+          "when": "view == filters",
+          "group": "navigation@3"
         },
         {
-          "command": "log-analysis.exportFilters",
-          "when": "view == filters"
+          "command": "log-analysis.addProject",
+          "when": "view == filters.settings",
+          "group": "navigation@1"
+        },
+        {
+          "command": "log-analysis.openSettings",
+          "when": "view == filters.settings",
+          "group": "navigation@2"
+        },
+        {
+          "command": "log-analysis.refreshSettings",
+          "when": "view == filters.settings",
+          "group": "navigation@3"
         }
       ]
     },
@@ -166,6 +214,21 @@
         {
           "id": "filters",
           "name": "Filters"
+        }
+      ],
+      "filter_project_setting": [
+        {
+          "id": "filters.settings",
+          "name": "Projects"
+        }
+      ]
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "filter_project_setting",
+          "title": "Log Analysis",
+          "icon": "$(preview)"
         }
       ]
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { State } from "./extension";
-import { Group, generateRandomColor, generateSvgUri } from "./utils";
+import { generateRandomColor, generateSvgUri, setStatusBarMessage, getProjectSelectedIndex, setProjectSelectedFlag } from "./utils";
+import { readSettings, saveSettings } from "./settings";
 
 export function applyHighlight(
   state: State,
@@ -14,9 +15,9 @@ export function applyHighlight(
     let sourceCode = editor.document.getText();
     const sourceCodeArr = sourceCode.split("\n");
 
-    state.groupArr.forEach((group) => {
+    state.groups.forEach((group) => {
       //apply new decorations
-      group.filterArr.forEach((filter) => {
+      group.filters.forEach((filter) => {
         let filterCount = 0;
         //if filter's highlight is off, or this editor is in focus mode and filter is not shown, we don't want to put decorations
         //especially when a specific line fits more than one filter regex and some of them are shown while others are not.
@@ -51,85 +52,7 @@ export function applyHighlight(
         }
       });
     });
-  })
-}
-
-//record the important fields of each filter on a json object and open a new tab for the json
-export function exportFilters(state: State) {
-  const content = JSON.stringify({
-    groups: state.groupArr.map(group => ({
-      name: group.name,
-      isHighlighted: group.isHighlighted,
-      isShown: group.isShown,
-      filterArr: group.filterArr.map(filter => ({
-        regexText: filter.regex.source,
-        color: filter.color,
-        isHighlighted: filter.isHighlighted,
-        isShown: filter.isShown
-      }))
-    }))
-  }, null, 2);
-
-  vscode.workspace.openTextDocument({
-    content: content,
-    language: "json"
-  }).then(textDocument => {
-    vscode.window.showTextDocument(textDocument);
   });
-}
-
-//open a selected json file and parse each filter to add back
-export function importFilters(state: State) {
-  vscode.window
-    .showOpenDialog({
-      canSelectFiles: true,
-      canSelectMany: false,
-      filters: {
-        json: ["json"],
-      },
-    })
-    .then((uriArr) => {
-      if (!uriArr) {
-        return;
-      }
-      return vscode.workspace.openTextDocument(uriArr[0]);
-    })
-    .then((textDocument) => {
-      const text = textDocument!.getText();
-      const parsed = JSON.parse(text);
-      if (typeof parsed !== "object") {
-        return;
-      }
-      parsed.groups.map((g: any) => {
-        const groupId = `${Math.random()}`;
-        const group: Group = {
-          filterArr: [],
-          name: g.name as string,
-          isHighlighted: g.isHighlighted as boolean,
-          isShown: g.isShown as boolean,
-          id: groupId
-        };
-
-        g.filterArr.map((f: any) => {
-          const filterId = `${Math.random()}`;
-          const filter = {
-            regex: new RegExp(f.regexText),
-            color: f.color as string,
-            isHighlighted: f.isHighlighted as boolean,
-            isShown: f.isShown as boolean,
-            id: filterId,
-            iconPath: generateSvgUri(
-              f.color as string,
-              f.isHighlighted
-            ),
-            count: 0
-          };
-          group.filterArr.push(filter);
-        });
-        state.groupArr.push(group);
-      });
-      refreshEditors(state);
-    });
 }
 
 //set bool for whether the lines matched the given filter will be kept for focus mode
@@ -139,13 +62,13 @@ export function setVisibility(
   state: State
 ) {
   const id = treeItem.id;
-  const group = state.groupArr.find(group => (group.id === id));
+  const group = state.groups.find(group => (group.id === id));
   if (group !== undefined) {
     group.isShown = isShown;
-    group.filterArr.map(filter => (filter.isShown = isShown));
+    group.filters.map(filter => (filter.isShown = isShown));
   } else {
-    state.groupArr.map(group => {
-      const filter = group.filterArr.find(filter => (filter.id === id));
+    state.groups.map(group => {
+      const filter = group.filters.find(filter => (filter.id === id));
       if (filter !== undefined) {
         filter.isShown = isShown;
       }
@@ -178,10 +101,10 @@ export function turnOnFocusMode(state: State) {
 }
 
 export function deleteFilter(treeItem: vscode.TreeItem, state: State) {
-  state.groupArr.map(group => {
-    const deleteIndex = group.filterArr.findIndex(filter => (filter.id === treeItem.id));
+  state.groups.map(group => {
+    const deleteIndex = group.filters.findIndex(filter => (filter.id === treeItem.id));
     if (deleteIndex !== -1) {
-      group.filterArr.splice(deleteIndex, 1);
+      group.filters.splice(deleteIndex, 1);
     }
   });
   refreshEditors(state);
@@ -197,7 +120,7 @@ export function addFilter(treeItem: vscode.TreeItem, state: State) {
       if (regexStr === undefined) {
         return;
       }
-      const group = state.groupArr.find(group => (group.id === treeItem.id));
+      const group = state.groups.find(group => (group.id === treeItem.id));
       const id = `${Math.random()}`;
       const color = generateRandomColor();
       const filter = {
@@ -209,7 +132,7 @@ export function addFilter(treeItem: vscode.TreeItem, state: State) {
         iconPath: generateSvgUri(color, true),
         count: 0,
       };
-      group!.filterArr.push(filter);
+      group!.filters.push(filter);
       refreshEditors(state);
     });
 }
@@ -225,8 +148,8 @@ export function editFilter(treeItem: vscode.TreeItem, state: State) {
         return;
       }
       const id = treeItem.id;
-      state.groupArr.map(group => {
-        const filter = group.filterArr.find(filter => (filter.id === id));
+      state.groups.map(group => {
+        const filter = group.filters.find(filter => (filter.id === id));
         if (filter !== undefined) {
           filter.regex = new RegExp(regexStr);
         }
@@ -241,16 +164,16 @@ export function setHighlight(
   state: State
 ) {
   const id = treeItem.id;
-  const group = state.groupArr.find(group => (group.id === id));
+  const group = state.groups.find(group => (group.id === id));
   if (group !== undefined) {
     group.isHighlighted = isHighlighted;
-    group.filterArr.map(filter => {
+    group.filters.map(filter => {
       filter.isHighlighted = isHighlighted;
       filter.iconPath = generateSvgUri(filter.color, filter.isHighlighted);
     });
   } else {
-    state.groupArr.map(group => {
-      const filter = group.filterArr.find(filter => (filter.id === id));
+    state.groups.map(group => {
+      const filter = group.filters.find(filter => (filter.id === id));
       if (filter !== undefined) {
         filter.isHighlighted = isHighlighted;
         filter.iconPath = generateSvgUri(filter.color, filter.isHighlighted);;
@@ -288,9 +211,20 @@ export function refreshEditors(state: State) {
   state.filterTreeViewProvider.refresh();
 }
 
-export function refreshTreeView(state: State) {
+export function refreshFilterTreeView(state: State) {
   console.log("refresh only tree view");
   state.filterTreeViewProvider.refresh();
+}
+
+export function updateFilterTreeViewAndFocusProvider(state: State) {
+  console.log("update filter and tree view");
+  state.filterTreeViewProvider.update(state.groups);
+  state.focusProvider.update(state.groups);
+}
+
+export function updateProjectTreeView(state: State) {
+  console.log("update project tree view");
+  state.projectTreeViewProvider.update(state.projects);
 }
 
 export function addGroup(state: State) {
@@ -303,14 +237,14 @@ export function addGroup(state: State) {
     }
     const id = `${Math.random()}`;
     const group = {
-      filterArr: [],
+      filters: [],
       isHighlighted: true,
       isShown: true,
       name: name,
       id
     };
-    state.groupArr.push(group);
-    refreshTreeView(state);
+    state.groups.push(group);
+    refreshFilterTreeView(state);
   });
 }
 
@@ -323,16 +257,179 @@ export function editGroup(treeItem: vscode.TreeItem, state: State) {
       return;
     }
     const id = treeItem.id;
-    const group = state.groupArr.find(group => (group.id === id));
+    const group = state.groups.find(group => (group.id === id));
     group!.name = name;
-    refreshTreeView(state);
+    refreshFilterTreeView(state);
   });
 }
 
 export function deleteGroup(treeItem: vscode.TreeItem, state: State) {
-  const deleteIndex = state.groupArr.findIndex(group => (group.id === treeItem.id));
+  const deleteIndex = state.groups.findIndex(group => (group.id === treeItem.id));
   if (deleteIndex !== -1) {
-    state.groupArr.splice(deleteIndex, 1);
+    state.groups.splice(deleteIndex, 1);
   }
   refreshEditors(state);
+}
+
+export function saveProject(state: State) {
+  if (state.groups.length === 0) {
+    vscode.window.showErrorMessage('There is no filter groups');
+    return;
+  }
+
+  const selected = state.projects.find(p => (p.selected === true));
+  if (selected === undefined) {
+    vscode.window.showErrorMessage('There is no selected project');
+    return;
+  }
+
+  selected.groups = state.groups;
+  saveSettings(state.globalStorageUri, state.projects);
+
+  setStatusBarMessage(`Project(${selected.name}) is saved.`);
+}
+
+export function addProject(state: State) {
+  vscode.window.showInputBox({
+    prompt: "[PROJECT] Type a new project name",
+    ignoreFocusOut: false
+  }).then(name => {
+    if (name === undefined) {
+      return;
+    }
+
+    const project = {
+      groups: [],
+      name,
+      id: `${Math.random()}`,
+      selected: false
+    };
+
+    state.projects.push(project);
+    saveSettings(state.globalStorageUri, state.projects);
+    updateProjectTreeView(state);
+  });
+}
+
+export function editProject(treeItem: vscode.TreeItem, state: State, callback: () => void) {
+  vscode.window
+    .showInputBox({
+      prompt: "[PROJECT] Type a new name",
+      ignoreFocusOut: false,
+    })
+    .then((name) => {
+      if (name === undefined) {
+        return;
+      }
+      const findIndex = state.projects.findIndex(project => (project.id === treeItem.id));
+      if (findIndex !== -1) {
+        state.projects[findIndex].name = name;
+        saveSettings(state.globalStorageUri, state.projects);
+        updateProjectTreeView(state);
+
+        callback();
+      }
+    });
+}
+
+export function deleteProject(treeItem: vscode.TreeItem, state: State) {
+  const selectedIndex = getProjectSelectedIndex(state.projects);
+  const deleteIndex = state.projects.findIndex(project => (project.id === treeItem.id));
+  if (deleteIndex !== -1) {
+    if (deleteIndex === selectedIndex) {
+      state.groups = [];
+      updateFilterTreeViewAndFocusProvider(state);
+      refreshEditors(state);
+    }
+    state.projects.splice(deleteIndex, 1);
+    saveSettings(state.globalStorageUri, state.projects);
+    updateProjectTreeView(state);
+  }
+}
+
+function createDefaultProject(state: State) {
+  const name = "NONAME";
+
+  if (state.projects.length === 0 || state.projects[0].name !== name) {
+    const project = {
+      groups: [],
+      name,
+      id: `${Math.random()}`,
+      selected: false
+    };
+
+    state.projects.unshift(project);
+  }
+}
+
+export function refreshSettings(state: State) {
+  state.projects = readSettings(state.globalStorageUri);
+  var selectedIndex = -1;
+
+  // Automatically activate the project if there is only one
+  if (state.projects.length === 1) {
+    selectedIndex = 0;
+  }
+
+  // Add a project named "NONAMED" in the following cases:
+  // - A default project is generated for users who do not use the project feature.
+  // - If multiple projects are available but none is selected, an empty project is created and selected.
+  if (state.projects.length === 0) {
+    createDefaultProject(state);
+    saveSettings(state.globalStorageUri, state.projects);
+    selectedIndex = 0;
+  }
+
+  if (selectedIndex === -1) {
+    createDefaultProject(state);
+    selectedIndex = 0;
+  }
+
+  setProjectSelectedFlag(state.projects, selectedIndex);
+  state.groups = state.projects[selectedIndex].groups;
+
+  updateProjectTreeView(state);
+  updateFilterTreeViewAndFocusProvider(state);
+  refreshEditors(state);
+}
+
+export function selectProject(treeItem: vscode.TreeItem, state: State): boolean {
+  const prevSelectedIndex = getProjectSelectedIndex(state.projects);
+  const newSelectedIndex = state.projects.findIndex(p => p.id === treeItem.id);
+  if (newSelectedIndex !== -1) {
+    if (prevSelectedIndex === newSelectedIndex) {
+      vscode.window.showInformationMessage('This project is already selected');
+      return true;
+    }
+    state.projects.forEach(p => {
+      p.selected = false;
+      p.groups.forEach(g => {
+        g.isHighlighted = false;
+        g.isShown = false;
+        g.filters.forEach(f => {
+          f.isHighlighted = false;
+          f.isShown = false;
+          f.iconPath = generateSvgUri(f.color, f.isHighlighted);
+        });
+      });
+    });
+
+    const project = state.projects[newSelectedIndex];
+    state.groups = project.groups;
+    setProjectSelectedFlag(state.projects, newSelectedIndex);
+    updateProjectTreeView(state);
+    updateFilterTreeViewAndFocusProvider(state);
+    refreshEditors(state);
+    return true;
+  }
+  return false;
+}
+
+export function updateExplorerTitle(view: vscode.TreeView<vscode.TreeItem>, state: State) {
+  const selectedIndex = getProjectSelectedIndex(state.projects);
+  if (selectedIndex === -1) {
+    view.title = 'Filters';
+  } else {
+    view.title = 'Filters (' + state.projects[selectedIndex].name + ')';
+  }
 }

--- a/src/focusProvider.ts
+++ b/src/focusProvider.ts
@@ -6,10 +6,10 @@ import { Filter, Group } from "./utils";
 //<original uri> is the escaped uri of the original, unfocused document.
 //VSCode uses this provider to generate virtual read-only files based on real files
 export class FocusProvider implements vscode.TextDocumentContentProvider {
-  groupArr: Group[];
+  groups: Group[];
 
-  constructor(groupArr: Group[]) {
-    this.groupArr = groupArr;
+  constructor(groups: Group[]) {
+    this.groups = groups;
   }
 
   //open the original document specified by the uri and return the focused version of its text
@@ -22,8 +22,8 @@ export class FocusProvider implements vscode.TextDocumentContentProvider {
 
     for (let lineIdx = 0; lineIdx < sourceCode.lineCount; lineIdx++) {
       const line = sourceCode.lineAt(lineIdx).text;
-      for (const group of this.groupArr) {
-        for (const filter of group.filterArr) {
+      for (const group of this.groups) {
+        for (const filter of group.filters) {
           if (!filter.isShown) {
             continue;
           }
@@ -44,5 +44,9 @@ export class FocusProvider implements vscode.TextDocumentContentProvider {
   //when this function gets called, the provideTextDocumentContent will be called again
   refresh(uri: vscode.Uri): void {
     this.onDidChangeEmitter.fire(uri);
+  }
+
+  update(groups: Group[]) {
+    this.groups = groups;
   }
 }

--- a/src/projectTreeViewProvider.ts
+++ b/src/projectTreeViewProvider.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+import { Project } from "./utils";
+
+export class ProjectTreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  constructor(private projects: Project[]) { }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: vscode.TreeItem): Thenable<vscode.TreeItem[]> {
+    if (element === undefined) {
+      return Promise.resolve(this.projects.map(project => new ProjectItem(project)));
+    } else {
+      return Promise.resolve([]);
+    }
+  }
+
+  private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined> = new vscode.EventEmitter<vscode.TreeItem | undefined>();
+  readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined> = this._onDidChangeTreeData.event;
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  update(projects: Project[]) {
+    this.projects = projects;
+    this.refresh();
+  }
+}
+
+export class ProjectItem extends vscode.TreeItem {
+  constructor(project: Project) {
+    super(project.name, vscode.TreeItemCollapsibleState.None);
+    this.id = project.id;
+    this.command = {
+      command: 'log-analysis.selectProject',
+      title: 'Select Project',
+      arguments: [this]
+    } as vscode.Command;
+    if (project.selected) {
+      this.iconPath = new vscode.ThemeIcon("arrow-small-right");
+    }
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,90 @@
+import * as vscode from "vscode";
+import * as path from 'path';
+import * as fs from 'fs';
+import { Project, Group, Filter, generateSvgUri } from './utils';
+
+function getSettingFile(storageUri: vscode.Uri): string {
+    const storagePath: string = storageUri.fsPath;
+
+    // Create the directory if it does not exist
+    if (!fs.existsSync(storagePath)) {
+        fs.mkdirSync(storagePath, { recursive: true });
+    }
+
+    return path.join(storagePath, 'vscode_log_analysis.json');
+}
+
+export function openSettings(storageUri: vscode.Uri) {
+    const settingFile = getSettingFile(storageUri);
+
+    vscode.workspace.openTextDocument(settingFile).then((doc) => {
+        vscode.window.showTextDocument(doc);
+    });
+}
+
+export function readSettings(storageUri: vscode.Uri): Project[] {
+    const settingFile = getSettingFile(storageUri);
+    const projects: Project[] = [];
+
+    if (fs.existsSync(settingFile)) {
+        try {
+            const text = fs.readFileSync(settingFile, 'utf8');
+            const parsed = JSON.parse(text);
+
+            parsed.projects.map((p: Project) => {
+                const project: Project = {
+                    groups: [],
+                    name: p.name,
+                    id: `${Math.random()}`,
+                    selected: false
+                };
+                p.groups.map((g: Group) => {
+                    const group: Group = {
+                        filters: [],
+                        name: g.name as string,
+                        isHighlighted: false,
+                        isShown: false,
+                        id: `${Math.random()}`
+                    };
+                    g.filters.map((f: Filter) => {
+                        const filterId = `${Math.random()}`;
+                        const filter = {
+                            regex: new RegExp(f.regex),
+                            color: f.color as string,
+                            isHighlighted: false,
+                            isShown: false,
+                            id: filterId,
+                            iconPath: generateSvgUri(f.color, f.isHighlighted),
+                            count: 0
+                        };
+                        group.filters.push(filter);
+                    });
+                    project.groups.push(group);
+                });
+                projects.push(project);
+            });
+        } catch (e) {
+            vscode.window.showErrorMessage('The settings file is broken');
+        }
+    }
+    return projects;
+}
+
+export function saveSettings(storageUri: vscode.Uri, projects: Project[]) {
+    const settingFile = getSettingFile(storageUri);
+
+    const content = JSON.stringify({
+        projects: projects.map(project => ({
+            name: project.name,
+            groups: project.groups.map(group => ({
+                name: group.name,
+                filters: group.filters.map(filter => ({
+                    regex: filter.regex.source,
+                    color: filter.color,
+                }))
+            }))
+        }))
+    }, null, 2);
+
+    fs.writeFileSync(settingFile, content, 'utf8');
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,11 +12,18 @@ export type Filter = {
 };
 
 export type Group = {
-    filterArr: Filter[];
-    isHighlighted: boolean; // if the matching lines will be highlighted
-    isShown: boolean; //if the matching lines will be kept in focus mode
-    name: string;
-    id: string; //random generated number
+  filters: Filter[];
+  isHighlighted: boolean; // if the matching lines will be highlighted
+  isShown: boolean; //if the matching lines will be kept in focus mode
+  name: string;
+  id: string; //random generated number
+};
+
+export type Project = {
+  groups: Group[];
+  name: string;
+  id: string;
+  selected: boolean;
 };
 
 export function generateRandomColor(): string {
@@ -34,4 +41,23 @@ export function generateSvgUri(
   const svgContent = isHighlighted ? fullSvg : emptySvg;
   const dataUri = `data:image/svg+xml;base64,${btoa(svgContent)}`;
   return vscode.Uri.parse(dataUri);
+}
+
+export function setStatusBarMessage(message: string) {
+  vscode.window.setStatusBarMessage(`LOG ANALYSIS: ${message}`, 5000);
+}
+
+export function getProjectSelectedIndex(projects: Project[]): number {
+  const selectedIndex = projects.findIndex(p => p.selected);
+  return selectedIndex;
+}
+
+export function setProjectSelectedFlag(projects: Project[], index: number) {
+  projects.forEach(p => p.selected = false);
+
+  if (index >= 0 && index < projects.length) {
+    projects[index].selected = true;
+  } else {
+    console.log(`Invalid index: ${index}`);
+  }
 }


### PR DESCRIPTION
Add a menu for project management to the Activity Bar. Users can select a project
from the project list, and the filter groups for the selected project will be loaded.
By default, filter and group properties are loaded as disabled.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>