### PR TITLE
add feature: support for exclude filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,16 @@
         "icon": "$(plus)"
       },
       {
+        "command": "log-analysis.addExFilter",
+        "title": "Add a Exclusion Filter",
+        "icon": "$(plus)"
+      },
+      {
+        "command": "log-analysis.deleteExGroup",
+        "title": "Delete This Exclusion Group",
+        "icon": "$(trash)"
+      },
+      {
         "command": "log-analysis.deleteProject",
         "title": "Delete This Project",
         "icon": "$(dialog-close)"
@@ -125,7 +135,7 @@
         },
         {
           "command": "log-analysis.editFilter",
-          "when": "view == filters && viewItem =~ /^f-/",
+          "when": "(view == filters || view == filters.minus) && viewItem =~ /^f-/",
           "group": "inline@2"
         },
         {
@@ -145,12 +155,12 @@
         },
         {
           "command": "log-analysis.disableVisibility",
-          "when": "view == filters && viewItem =~ /-visible/",
+          "when": "(view == filters || view == filters.minus) && viewItem =~ /-visible/",
           "group": "inline@4"
         },
         {
           "command": "log-analysis.enableVisibility",
-          "when": "view == filters && viewItem =~ /-invisible/",
+          "when": "(view == filters || view == filters.minus) && viewItem =~ /-invisible/",
           "group": "inline@4"
         },
         {
@@ -160,7 +170,7 @@
         },
         {
           "command": "log-analysis.deleteFilter",
-          "when": "view == filters && viewItem =~ /^f-/",
+          "when": "(view == filters || view == filters.minus) && viewItem =~ /^f-/",
           "group": "inline@5"
         },
         {
@@ -199,6 +209,16 @@
           "command": "log-analysis.refreshSettings",
           "when": "view == filters.settings",
           "group": "navigation@3"
+        },
+        {
+          "command": "log-analysis.addExFilter",
+          "when": "view == filters.minus",
+          "group": "navigation@1"
+        },
+        {
+          "command": "log-analysis.deleteExGroup",
+          "when": "view == filters.minus",
+          "group": "navigation@2"
         }
       ]
     },
@@ -213,7 +233,11 @@
       "explorer": [
         {
           "id": "filters",
-          "name": "Filters"
+          "name": "Filters+"
+        },
+        {
+          "id": "filters.minus",
+          "name": "Filters-"
         }
       ],
       "filter_project_setting": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -67,6 +67,11 @@ export function setVisibility(
     group.isShown = isShown;
     group.filters.map(filter => (filter.isShown = isShown));
   } else {
+    const filter = state.exFilters.find(filter => (filter.id === id));
+    if (filter !== undefined) {
+      filter.isShown = isShown;
+    }
+
     state.groups.map(group => {
       const filter = group.filters.find(filter => (filter.id === id));
       if (filter !== undefined) {
@@ -101,6 +106,11 @@ export function turnOnFocusMode(state: State) {
 }
 
 export function deleteFilter(treeItem: vscode.TreeItem, state: State) {
+  const deleteIndex = state.exFilters.findIndex(filter => (filter.id === treeItem.id));
+  if (deleteIndex !== -1) {
+    state.exFilters.splice(deleteIndex, 1);
+  }
+
   state.groups.map(group => {
     const deleteIndex = group.filters.findIndex(filter => (filter.id === treeItem.id));
     if (deleteIndex !== -1) {
@@ -148,6 +158,10 @@ export function editFilter(treeItem: vscode.TreeItem, state: State) {
         return;
       }
       const id = treeItem.id;
+      const exFilter = state.exFilters.find(filter => (filter.id === id));
+      if (exFilter !== undefined) {
+        exFilter.regex = new RegExp(regexStr);
+      }
       state.groups.map(group => {
         const filter = group.filters.find(filter => (filter.id === id));
         if (filter !== undefined) {
@@ -209,6 +223,7 @@ export function refreshEditors(state: State) {
   applyHighlight(state, vscode.window.visibleTextEditors);
   console.log("refreshEditors");
   state.filterTreeViewProvider.refresh();
+  state.exFilterTreeViewProvider.refresh();
 }
 
 export function refreshFilterTreeView(state: State) {
@@ -432,4 +447,33 @@ export function updateExplorerTitle(view: vscode.TreeView<vscode.TreeItem>, stat
   } else {
     view.title = 'Filters (' + state.projects[selectedIndex].name + ')';
   }
+}
+
+export function addExFilter(state: State) {
+  vscode.window.showInputBox({
+    prompt: "[FILTER] Type a regex to exclusion filter",
+    ignoreFocusOut: false
+  }).then(regexStr => {
+    if (regexStr === undefined) {
+      return;
+    }
+    const id = `${Math.random()}`;
+    const exFilter = {
+      isHighlighted: false, // don't care
+      isShown: true,
+      regex: new RegExp(regexStr),
+      color: generateRandomColor(), // don't care
+      id,
+      iconPath: generateSvgUri(generateRandomColor(), false),
+      count: 0 // don't care
+    };
+
+    state.exFilters.push(exFilter);
+    refreshEditors(state);
+  });
+}
+
+export function deleteExGroup(state: State) {
+  state.exFilters.splice(0, state.exFilters.length);
+  refreshEditors(state);
 }

--- a/src/exFilterTreeViewProvider.ts
+++ b/src/exFilterTreeViewProvider.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { Filter } from "./utils";
+
+//provides filters as tree items to be displayed on the sidebar
+export class ExFilterTreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  constructor(private filters: Filter[]) { }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: vscode.TreeItem): Thenable<vscode.TreeItem[]> {
+    if (element === undefined) {
+      return Promise.resolve(this.filters.map(filter => new FilterItem(filter)));
+    } else {
+      return Promise.resolve([]);
+    }
+  }
+
+  private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined> = new vscode.EventEmitter<vscode.TreeItem | undefined>();
+  readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined> = this._onDidChangeTreeData.event;
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+}
+
+//represents a filter as one row in the sidebar
+export class FilterItem extends vscode.TreeItem {
+  constructor(
+    filter: Filter,
+  ) {
+    super(filter.regex.toString(), vscode.TreeItemCollapsibleState.None);
+    this.contextValue = 'f-invisible';
+    this.update(filter);
+  }
+
+  update(filter: Filter) {
+    this.label = filter.regex.toString();
+    this.id = filter.id;
+
+    if (filter.isShown) {
+      this.description = ` · ${filter.count}`;
+      this.contextValue = 'f-visible';
+      this.iconPath = new vscode.ThemeIcon("bracket-error");
+    } else {
+      this.description = '';
+      this.contextValue = 'f-invisible';
+      this.iconPath = undefined;
+    }
+  }
+
+  //contextValue connects to package.json>menus>view/item/context
+  contextValue:
+    | 'f-visible'
+    | 'f-invisible';
+}


### PR DESCRIPTION
Even after applying filters, unnecessary information may still be included.
Removing meaningless information would aid in issue analysis.
For exclusion filters, they are volatile properties applied as needed and
are not stored or managed in the settings file. A `Filter-` view has been
created for managing these filter settings.

Signed-off-by: JeanTracker <hyojoong.kim.jean@gmail.com>